### PR TITLE
perf(roadmap): add TaskDTO interface and update listTasks method

### DIFF
--- a/packages/lib/src/dtos/TaskDTO.ts
+++ b/packages/lib/src/dtos/TaskDTO.ts
@@ -1,0 +1,6 @@
+export interface TaskDTO {
+  title: string;
+  status?: string;
+  expectedCompletionDate?: string;
+  expectedReleaseDate?: string;
+}

--- a/packages/lib/src/roadmap_file.ts
+++ b/packages/lib/src/roadmap_file.ts
@@ -4,6 +4,7 @@ import { gfmTableFromMarkdown } from "mdast-util-gfm-table";
 import { gfmTable } from "micromark-extension-gfm-table";
 import * as mdastUtilFromMarkdown from "mdast-util-from-markdown";
 import * as mdastUtilToMarkdown from "mdast-util-to-markdown";
+import type { TaskDTO } from "./dtos/TaskDTO";
 
 const toRef = (str: string) => str.toLocaleLowerCase().replace(/\W/g, "-");
 
@@ -178,7 +179,7 @@ export class RoadmapFile {
     ];
   }
 
-  async listTasks() {
+  async listTasks(): Promise<TaskDTO[]> {
     const infoTasks = await this.infoTasks();
     const proposalsHeader = this.markdown.children.find(
       (n) => n.type === "heading" && /proposals/i.test(nodeToTextContent(n)),


### PR DESCRIPTION
Here is the pull request description:

This pull request introduces the following changes:

1. Added a new `TaskDTO` interface in the `dtos/TaskDTO.ts` file. This interface defines the structure of a task, including its title, status, expected completion date, and expected release date.

2. Updated the `listTasks()` method in the `roadmap_file.ts` file to return a `Promise<TaskDTO[]>` instead of just an array of tasks. This change aligns the method's return type with the newly added `TaskDTO` interface.

These changes were made to improve the overall structure and type safety of the codebase, making it easier to work with task data in the future.