### PR TITLE
build(release-please): update package name for roadmap-parse

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -10,6 +10,7 @@
       "prerelease": false
     },
     "packages/lib": {
+      "name": "roadmap-parse",
       "changelog-path": "CHANGELOG.md",
       "release-type": "node",
       "bump-minor-pre-major": false,


### PR DESCRIPTION
Adds the package name "roadmap-parse" to the release-please
configuration for the "packages/lib" package. This ensures that
the release notes and changelog are generated correctly for
this package.