### PR TITLE
docs(roadmap-parse): add support for reading ROADMAP.md from memory

### DIFF
--- a/packages/lib/docs/es/README.md
+++ b/packages/lib/docs/es/README.md
@@ -110,10 +110,34 @@ import { RoadmapFile } from "@jondotsoy/roadmap-parse";
 
 ### Leer un Archivo ROADMAP.md
 
-La clase `RoadmapFile` proporciona un método estático `fromFile(filePath: string)` que lee un archivo `ROADMAP.md` y crea una instancia de `RoadmapFile`. Este método devuelve una Promesa que se resuelve con la instancia de `RoadmapFile` una vez que el archivo ha sido leído y analizado.
+La clase `RoadmapFile` proporciona el método estático `fromFile`. Este método tiene dos formas de uso:
+
+1.  **Desde un archivo en disco:** `fromFile(filePath: string)` lee un archivo `ROADMAP.md` ubicado en la ruta `filePath` y crea una instancia de `RoadmapFile`.
+2.  **Desde un buffer en memoria:** `fromFile(filePath: string, buffer: Uint8Array)` lee el contenido de `ROADMAP.md` directamente desde un `Uint8Array` que contiene el contenido del archivo en memoria. Esta opción es útil cuando ya tienes el contenido del roadmap en memoria y quieres evitar la necesidad de escribirlo en disco.
+
+Ambas formas del método `fromFile` devuelven una Promesa que se resuelve con la instancia de `RoadmapFile` una vez que el contenido ha sido leído y analizado.
+
+**Ejemplo de lectura desde un buffer:**
 
 ```typescript
-const roadmapFile = await RoadmapFile.fromFile("./ROADMAP.md");
+import { RoadmapFile } from "@jondotsoy/roadmap-parse";
+import fs from "node:fs/promises"; // o 'fs' si usas CommonJS
+
+async function main() {
+  try {
+    const readmePath = "./README.md"; // Reemplaza con la ruta a tu archivo ROADMAP.md
+    const roadmapBuffer = await fs.readFile(readmePath); // Lee el archivo a un buffer (Uint8Array)
+
+    const roadmapFile = await RoadmapFile.fromFile(readmePath, roadmapBuffer); // Usa fromFile con el buffer
+    const tasks = await roadmapFile.listTasks();
+
+    console.log(JSON.stringify(tasks, null, 2));
+  } catch (error) {
+    console.error("Error al procesar ROADMAP.md:", error);
+  }
+}
+
+main();
 ```
 
 ### Listar las Tareas


### PR DESCRIPTION
This pull request adds support for reading the ROADMAP.md file directly from a `Uint8Array` buffer, instead of from a file on disk. This is useful when the roadmap content is already available in memory and you want to avoid the need to write it to disk first.

The changes include:

- Added a new overload to the `RoadmapFile.fromFile` method that accepts a `Uint8Array` buffer as input.
- Documented the new overload and provided an example usage to demonstrate how to use it.

These changes will improve the flexibility and usability of the roadmap parsing functionality, allowing users to work with the roadmap data more efficiently when it's already available in memory.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #24 
- <kbd>&nbsp;1&nbsp;</kbd> #22 👈 
<!-- GitButler Footer Boundary Bottom -->

