### PR TITLE
chore: add CHANGELOG.md to .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+CHANGELOG.md


### PR DESCRIPTION
**Pull Request Description:**

This pull request adds the `CHANGELOG.md` file to the `.prettierignore` file. This is necessary to prevent Prettier from formatting the `CHANGELOG.md` file, which is typically manually maintained to preserve its formatting.

The changes include:

- Adding `CHANGELOG.md` to the `.prettierignore` file to exclude it from Prettier formatting.

This change will help maintain the proper formatting of the `CHANGELOG.md` file, which is an important part of the project's documentation.