### PR TITLE
docs(roadmap-parse): add support for reading ROADMAP.md from buffer

### DIFF
--- a/packages/lib/README.md
+++ b/packages/lib/README.md
@@ -110,10 +110,34 @@ import { RoadmapFile } from "@jondotsoy/roadmap-parse";
 
 ### Reading a ROADMAP.md File
 
-The `RoadmapFile` class provides a static method `fromFile(filePath: string)` that reads a `ROADMAP.md` file and creates a `RoadmapFile` instance. This method returns a Promise that resolves with the `RoadmapFile` instance once the file has been read and parsed.
+The `RoadmapFile` class provides the static method `fromFile`. This method has two ways of being used:
+
+1.  **From a file on disk:** `fromFile(filePath: string)` reads a `ROADMAP.md` file located at `filePath` and creates a `RoadmapFile` instance.
+2.  **From an in-memory buffer:** `fromFile(filePath: string, buffer: Uint8Array)` reads the content of `ROADMAP.md` directly from a `Uint8Array` that contains the file content in memory. This option is useful when you already have the roadmap content in memory and want to avoid the need to write it to disk.
+
+Both forms of the `fromFile` method return a Promise that resolves with the `RoadmapFile` instance once the content has been read and parsed.
+
+**Example of reading from a buffer:**
 
 ```typescript
-const roadmapFile = await RoadmapFile.fromFile("./ROADMAP.md");
+import { RoadmapFile } from "@jondotsoy/roadmap-parse";
+import fs from "node:fs/promises"; // or 'fs' if you use CommonJS
+
+async function main() {
+  try {
+    const readmePath = "./README.md"; // Replace with the path to your ROADMAP.md file
+    const roadmapBuffer = await fs.readFile(readmePath); // Read the file into a buffer (Uint8Array)
+
+    const roadmapFile = await RoadmapFile.fromFile(readmePath, roadmapBuffer); // Use fromFile with the buffer
+    const tasks = await roadmapFile.listTasks();
+
+    console.log(JSON.stringify(tasks, null, 2));
+  } catch (error) {
+    console.error("Error processing ROADMAP.md:", error);
+  }
+}
+
+main();
 ```
 
 ### Listing Tasks
@@ -138,7 +162,7 @@ interface TaskDTO {
 ```
 
 - **`title`**: Always present and extracted from the "Feature" column of both tables ("Active" and "Planned").
-- **`status`**: Present **only** for tasks extracted from th`e "Planned" table and corresponds to the value of the "Status" column.
+- **`status`**: Present **only** for tasks extracted from the "Planned" table and corresponds to the value of the "Status" column.
 - **`expectedCompletionDate`**: Present **only** for tasks extracted from the "Planned" table and corresponds to the value of the "Expected Completion Date" column.
 - **`expectedReleaseDate`**: Present **only** for tasks extracted from the "Active" table and corresponds to the value of the "Expected Release Date" column.
 


### PR DESCRIPTION
Here is the pull request description:

This pull request adds support for reading the ROADMAP.md file from a buffer, in addition to the existing method that reads the file from disk.

The changes include:

- Added a new overload to the `RoadmapFile.fromFile` method that allows reading the file content directly from a `Uint8Array` buffer.
- This is useful when the roadmap content is already available in memory and you want to avoid the need to write it to disk.
- Updated the documentation to describe the new functionality.

These changes will provide more flexibility when working with ROADMAP.md files, allowing users to avoid the overhead of writing the file to disk in certain scenarios.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #24 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #22 
<!-- GitButler Footer Boundary Bottom -->

