### PR TITLE
Add use case naming rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,66 @@
+# AGENTS Instructions
+
+This repository stores a template ROADMAP and two packages:
+
+- **`packages/cli`** contains a command line tool to read the ROADMAP and list tasks.
+- **`packages/lib`** provides the `@jondotsoy/roadmap-parse` library that parses markdown ROADMAP files.
+
+Both packages are written in **TypeScript** and built with **Bun**.
+
+## Setup
+
+Install dependencies with:
+
+```bash
+bun install
+```
+
+## Building
+
+Compile the packages with:
+
+```bash
+make build
+```
+
+This calls the internal Makefiles for each package and produces the compiled library (`packages/lib/libs/esm`) and CLI binary (`packages/cli/dist/roadmap`).
+
+## Testing
+
+Run all tests using Bun:
+
+```bash
+bun test
+```
+
+Tests are located under `packages/lib/src/*.spec.ts` and `packages/cli/src/**/*.spec.ts` and use `bun:test`.
+
+## Formatting
+
+Check or apply formatting using Prettier:
+
+```bash
+make lint   # check
+make fmt    # rewrite files
+```
+
+## Usage Notes
+
+- A template ROADMAP file is available in `template/ROADMAP.md`.
+- The root `ROADMAP.md` file describes active and planned features.
+- The CLI can be executed after building via `dist/roadmap`.
+- All code follows the `.editorconfig` settings (2 spaces, LF line endings, tabs only in Makefiles).
+
+## Use Cases
+
+User stories are stored under the `use-cases` folder. Each file must be written
+in **Gherkin** and use the `.feature` extension. Use the naming pattern `UC-<number>-<short-title>.feature` where `<number>` increases without leading zeroes (e.g. `UC-1`, `UC-2`).
+
+Example location:
+
+```
+use-cases/UC-1-show-tasks.feature
+```
+
+Each feature starts with a `Feature` block followed by one or more `Scenario` sections.
+

--- a/README.md
+++ b/README.md
@@ -88,6 +88,23 @@ $ roadmap init
 # Roadmap initialized successfully!
 ```
 
+## Use Cases
+
+User stories are stored under the `use-cases` folder using the `.feature` extension. These files are written in **Gherkin** to clearly describe the desired behaviour.
+
+Each file follows the pattern `UC-<number>-<short-title>.feature` and defines a `Feature` with one or more `Scenario` sections. The `<number>` part increments sequentially without leading zeroes (e.g. `UC-1`, `UC-2`).
+
+Example:
+For instance, `use-cases/UC-1-show-tasks.feature` documents how the CLI lists tasks.
+
+```gherkin
+Feature: Show tasks from roadmap
+  Scenario: List tasks
+    Given a ROADMAP.md with pending tasks
+    When I run `roadmap`
+    Then the CLI outputs the tasks summary
+```
+
 ## License
 
 This project is published under the MIT License. You can view the full text of the license in the file [LICENSE](./LICENSE).

--- a/use-cases/README.md
+++ b/use-cases/README.md
@@ -1,0 +1,14 @@
+# Use Cases
+
+This folder stores user stories in **Gherkin** format. Each file represents one feature and must use the `.feature` extension.
+
+Naming convention:
+
+- `UC-<number>-<short-title>.feature` where `<number>` increases sequentially
+  without leading zeroes
+- Example: `UC-1-show-tasks.feature`
+
+Each feature contains a `Feature` description followed by one or more `Scenario` sections.
+
+Use two-space indentation and plain ASCII characters. Keep scenarios concise and focused on behaviour.
+

--- a/use-cases/UC-1-show-tasks.feature
+++ b/use-cases/UC-1-show-tasks.feature
@@ -1,0 +1,9 @@
+Feature: Show tasks from roadmap
+  As a CLI user
+  I want to list tasks defined in ROADMAP.md
+  So that I can track project progress
+
+  Scenario: List tasks
+    Given a ROADMAP.md with pending tasks
+    When I run `roadmap`
+    Then the CLI outputs the tasks summary


### PR DESCRIPTION
## Summary
- clarify numbering rule for use case files
- rename sample feature file to `UC-1-show-tasks.feature`
- update documentation examples accordingly

## Testing
- `make fmt` *(fails: bunx not found)*
- `bun test` *(fails: missing packages)*

------
https://chatgpt.com/codex/tasks/task_e_68637017f1a0832087f649bbaaf3b2f8