### PR TITLE
Fix command in all-branches use case

### DIFF
--- a/use-cases/UC-2-list-all-branches.feature
+++ b/use-cases/UC-2-list-all-branches.feature
@@ -1,0 +1,9 @@
+Feature: List tasks from all branches
+  As a CLI user
+  I want to fetch tasks from every branch
+  So that I can see all scheduled activities
+
+  Scenario: Fetch tasks across branches
+    Given a repository with ROADMAP files in multiple branches
+    When I run `roadmap --all`
+    Then all tasks from all branches are displayed


### PR DESCRIPTION
## Summary
- update CLI example to use `roadmap --all`

## Testing
- `bun test`
- `bun x prettier -c use-cases/UC-2-list-all-branches.feature`

------
https://chatgpt.com/codex/tasks/task_e_68667f6cf5748320bc4828501d3dc263